### PR TITLE
Add Docker support and improve Python 3 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9
+
+WORKDIR /rna
+
+ADD . /rna
+
+RUN python setup.py install
+
+ENTRYPOINT ["/bin/bash"]

--- a/README.mkd
+++ b/README.mkd
@@ -2,8 +2,33 @@
 
 [![Build Status](https://api.travis-ci.org/BGSU-RNA/fr3d-python.png?branch=develop)](https://travis-ci.org/BGSU-RNA/fr3d-python)
 
-This is an implementation of the FR3D program in python.
+**fr3d-python** is an implementation of the [FR3D](https://www.bgsu.edu/research/rna/software/fr3d.html) software in Python.
 
-To run the first time, navigate to the fr3d-python folder and run "python setup.py install"
+## Installation
 
-fr3d-python requires pdbx to be installed, which you can get from PDB, for Python 2.7.  To run pdbx in Python 3.x, one can use the 2to3 tool from https://docs.python.org/3.10/library/2to3.html  The main changes are changing iterator.next() to next(iterator), xrange() to (range), print string to print(string), and exec _ to exec()
+### With Docker
+
+Clone the repository and navigate to the `fr3d-python`, then run:
+
+```
+docker build -t fr3d .
+docker run -v `pwd`:/rna -it fr3d
+```
+
+### Without Docker
+
+1. Optional: create and activate a new virtual environment
+
+2. Clone the repository and navigate to the `fr3d-python`, then run:
+
+    ```
+    python setup.py install
+    ```
+
+## Usage
+
+To annotate a cif file:
+
+```
+python fr3d/classifiers/NA_pairwise_interactions.py
+```

--- a/fr3d/classifiers/NA_pairwise_interactions.py
+++ b/fr3d/classifiers/NA_pairwise_interactions.py
@@ -126,6 +126,7 @@ def get_structure(filename,PDB):
         if sys.version_info[0] < 3:
             urllib.urlretrieve("http://files.rcsb.org/download/%s.cif" % PDB, filename)  # python 2
         else:
+            import urllib.request
             urllib.request.urlretrieve("http://files.rcsb.org/download/%s.cif" % PDB, filename)  # python 3
 
     with open(filename, 'rb') as raw:

--- a/fr3d/classifiers/NA_pairwise_interactions.py
+++ b/fr3d/classifiers/NA_pairwise_interactions.py
@@ -129,7 +129,7 @@ def get_structure(filename,PDB):
             import urllib.request
             urllib.request.urlretrieve("http://files.rcsb.org/download/%s.cif" % PDB, filename)  # python 3
 
-    with open(filename, 'rb') as raw:
+    with open(filename, 'r') as raw:
         print("  Loading " + filename)
         structure = Cif(raw).structure()
         """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,13 @@ setup(
     packages=find_packages(include=['fr3d', 'fr3d.*']),
     url='',
     license='LICENSE.txt',
-    install_requires=['mmcif-pdbx', 'numpy', 'scipy'],
+    install_requires=[
+        'mmcif-pdbx==2.0.1',
+        'numpy==1.22.3',
+        'scipy==1.8.0',
+        'fonttools==4.31.2',
+        'matplotlib==3.5.1',
+    ],
     description='Python implementation of FR3D',
     long_description="""
     """


### PR DESCRIPTION
@tzok @clzirbel @blakesweeney 

I was working on dockerising *fr3d-python* so that it can run on the EBI cluster when I noticed [Tomasz' pull request](https://github.com/BGSU-RNA/fr3d-python/pull/7) that successfully updates the pdbx dependency to Python 3.

I built on that to make sure that the `NA_pairwise_interactions.py` script runs without errors and the installation process is fully reproducible.

It would be great if this code can be merged into Tomasz' repo and from there into the BG repo. Please let me know if you have any comments or feedback. Thank you!